### PR TITLE
feat: support babashka except in print

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,5 @@
+;; only used for tests in scripts/test.sh
+{:min-bb-version "1.12.209"
+ :paths          ["src" "dev" "test"]
+ :deps           {io.github.tonsky/clojure-plus {:local/root "."}
+                  io.github.tonsky/clj-reload   {:mvn/version "1.0.0"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,7 @@
  {:dev
   {:extra-paths ["dev" "test"]
    :extra-deps
-   {io.github.tonsky/clj-reload {:mvn/version "0.9.4"}}
+   {io.github.tonsky/clj-reload {:mvn/version "1.0.0"}}
    :jvm-opts ["-ea"
               "-Dclojure.main.report=stderr"
               "-Duser.language=en"

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,6 +1,7 @@
 (ns user
   (:require
    [clj-reload.core :as reload]
+   [clojure+.core :as core]
    [clojure.core.server :as server]
    [clojure.java.io :as io]
    [clojure.test :as test]))
@@ -42,9 +43,14 @@
         (test/do-report (assoc @test/*report-counters* :type :summary))
         @test/*report-counters*))))
 
+(def test-re
+  (core/if-not-bb
+    #"clojure\+\.(?!test-test$).*"
+    #"clojure\+\.(?!test-test$|print-test$|print$).*"))
+
 (defn test-all []
-  (run-tests #"clojure\+\.(?!test-test$).*"))
+  (run-tests test-re))
 
 (defn -test-main [_]
-  (let [{:keys [fail error]} (run-tests #"clojure\+\.(?!test-test$).*")]
+  (let [{:keys [fail error]} (run-tests test-re)]
     (System/exit (+ fail error))))

--- a/script/test.sh
+++ b/script/test.sh
@@ -3,3 +3,5 @@ set -o errexit -o nounset -o pipefail
 cd "`dirname $0`/.."
 
 clojure -X:dev:test user/-test-main
+# bb -x user/-test-main # doesn't work https://github.com/babashka/babashka/issues/1867, workaround below
+bb -e "(require 'user :reload) (user/-test-main nil)"

--- a/src/clojure+/core.clj
+++ b/src/clojure+/core.clj
@@ -30,6 +30,16 @@
      if-branch
      else-branch)))
 
+(def bb? (System/getProperty "babashka.version"))
+
+(defmacro if-not-bb
+  ([if-branch]
+   `(if-not-bb ~if-branch nil))
+  ([if-branch else-branch]
+   (if (not bb?)
+     if-branch
+     else-branch)))
+
 (defn- if+-rewrite-cond-impl [cond]
   (clojure.core/cond
     (empty? cond)

--- a/src/clojure+/error.clj
+++ b/src/clojure+/error.clj
@@ -400,7 +400,7 @@
   ([]
    (install! {}))
   ([opts]
-   (.doReset #'config (merge (default-config) opts))
+   (alter-var-root #'config (constantly (merge (default-config) opts)))
    (.addMethod ^MultiFn print-method Throwable patched-print-method)))
 
 (defn uninstall!

--- a/src/clojure+/hashp.clj
+++ b/src/clojure+/hashp.clj
@@ -123,7 +123,7 @@
    (install! {}))
   ([opts]
    (let [config (merge (default-config) opts)
-         _      (.doReset #'config config)
+         _      (alter-var-root #'config (constantly config))
          sym    (:symbol config)]
      (alter-var-root #'*data-readers* assoc sym #'hashp)
      (when (thread-bound? #'*data-readers*)

--- a/src/clojure+/test.clj
+++ b/src/clojure+/test.clj
@@ -37,10 +37,10 @@
   (default-config))
 
 (defn- capture-output []
-  (Var/.doReset #'system-out System/out)
-  (Var/.doReset #'system-err System/err)
-  (Var/.doReset #'clojure-test-out test/*test-out*)
-  
+  (alter-var-root #'system-out (constantly System/out))
+  (alter-var-root #'system-err (constantly System/err))
+  (alter-var-root #'clojure-test-out (constantly test/*test-out*))
+
   (let [buffer (ByteArrayOutputStream.)
         ps     (PrintStream. buffer)
         out    (OutputStreamWriter. buffer)]
@@ -67,9 +67,9 @@
   (pop-thread-bindings)
   (System/setErr system-err)
   (System/setOut system-out)
-  (Var/.doReset #'clojure-test-out nil)
-  (Var/.doReset #'system-err nil)
-  (Var/.doReset #'system-out nil))
+  (alter-var-root #'clojure-test-out (constantly nil))
+  (alter-var-root #'system-err (constantly nil))
+  (alter-var-root #'system-out (constantly nil)))
 
 (defn- inc-report-counter [name]
   (condp instance? test/*report-counters*
@@ -294,13 +294,13 @@
 
 (defn install!
   "Improves output of clojure.test. Possible options:
-   
+
      :capture-output?  <bool> :: Whether output of successful tests should be
                                  silenced. True by default."
   ([]
    (install! {}))
   ([opts]
-   (.doReset #'config (merge (default-config) opts))
+   (alter-var-root #'config (constantly (merge (default-config) opts)))
    (doseq [[k m] patched-methods-report]
      (.addMethod ^MultiFn test/report k @m))
    (.addMethod ^MultiFn test/assert-expr '= assert-expr-=)

--- a/test/clojure+/hashp_test.clj
+++ b/test/clojure+/hashp_test.clj
@@ -122,7 +122,9 @@
       (core/if-clojure-version-gte "1.12.0"
         (do
           (is (= "#p String/1 [<pos>]\njava.lang.String/1\n"                              (:out (eval "#p String/1"))))
-          (is (= "#p StringWriter/1 [<pos>]\njava.io.StringWriter/1\n"                    (:out (eval "#p StringWriter/1")))))))
+          (core/if-not-bb
+            ;; not in bb
+            (is (= "#p StringWriter/1 [<pos>]\njava.io.StringWriter/1\n"                  (:out (eval "#p StringWriter/1"))))))))
 
     (testing "static methods"
       (is (= {:res [] :out "#p (Collections/emptyList) [<pos>]\n[]\n"}          (eval "#p (Collections/emptyList)")))
@@ -152,11 +154,13 @@
       (is (= {:res "b" :out "#p (. \"abc\" substring 1 2) [<pos>]\n\"b\"\n"}       (eval "#p (. \"abc\" substring 1 2)")))
       (is (= {:res "b" :out "#p (. \"abc\" (substring 1 2)) [<pos>]\n\"b\"\n"}     (eval "#p (. \"abc\" (substring 1 2))"))))
 
-    (testing "instance fields"
-      (is (= {:res 1 :out "#p (.-x (java.awt.Point. 1 2)) [<pos>]\n1\n"}  (eval "#p (.-x (java.awt.Point. 1 2))")))
-      (is (= {:res 1 :out "#p (.x (java.awt.Point. 1 2)) [<pos>]\n1\n"}   (eval "#p (.x (java.awt.Point. 1 2))")))
-      (is (= {:res 1 :out "#p (. (java.awt.Point. 1 2) -x) [<pos>]\n1\n"} (eval "#p (. (java.awt.Point. 1 2) -x)")))
-      (is (= {:res 1 :out "#p (. (java.awt.Point. 1 2) x) [<pos>]\n1\n"}  (eval "#p (. (java.awt.Point. 1 2) x)"))))
+    (core/if-not-bb
+      ;; no built-in classes with instance fields in bb
+      (testing "instance fields"
+        (is (= {:res 1 :out "#p (.-x (java.awt.Point. 1 2)) [<pos>]\n1\n"}  (eval "#p (.-x (java.awt.Point. 1 2))")))
+        (is (= {:res 1 :out "#p (.x (java.awt.Point. 1 2)) [<pos>]\n1\n"}   (eval "#p (.x (java.awt.Point. 1 2))")))
+        (is (= {:res 1 :out "#p (. (java.awt.Point. 1 2) -x) [<pos>]\n1\n"} (eval "#p (. (java.awt.Point. 1 2) -x)")))
+        (is (= {:res 1 :out "#p (. (java.awt.Point. 1 2) x) [<pos>]\n1\n"}  (eval "#p (. (java.awt.Point. 1 2) x)")))))
 
     (testing "constructors"
       (is (= {:res 1 :out "#p (Long. 1) [<pos>]\n1\n"}    (eval "#p (Long. 1)")))


### PR DESCRIPTION
After https://github.com/babashka/babashka/issues/1871, https://github.com/babashka/babashka/issues/1870, and https://github.com/babashka/babashka/issues/1869, it wasn't very hard to support Babashka for most namespaces in this repo.

`clojure+.print` was the exception, as you can see in https://github.com/tonsky/clojure-plus/pull/19/commits/bd6a9b6de7e4726c9902dbc12b05e2f15bc9babf. That one would require a lot of changes, which I don't feel it's worth it.

The changes in `clojure+.walk-test` are due to https://github.com/babashka/babashka/issues/1868 though, and the lack of `.comparator`.

Supersedes https://github.com/tonsky/clojure-plus/pull/19
Fix https://github.com/babashka/babashka/issues/1853

