### PR TITLE
Rename clj-kondo hooks namespace to avoid clashes

### DIFF
--- a/src/clj-kondo.exports/io.github.tonsky/clojure-plus/clojure+/kondo_hooks.clj
+++ b/src/clj-kondo.exports/io.github.tonsky/clojure-plus/clojure+/kondo_hooks.clj
@@ -1,4 +1,4 @@
-(ns ^:no-doc hooks.core
+(ns ^:no-doc clojure+.kondo-hooks
   "A clj-kondo hook to allow linting of `if+` macro."
   (:require
    [clj-kondo.hooks-api :as api]))

--- a/src/clj-kondo.exports/io.github.tonsky/clojure-plus/config.edn
+++ b/src/clj-kondo.exports/io.github.tonsky/clojure-plus/config.edn
@@ -1,5 +1,5 @@
 {:hooks
  {:analyze-call
-  {clojure+.core/if+   hooks.core/ifplus-hook
-   clojure+.core/when+ hooks.core/whenplus-hook
-   clojure+.core/cond+ hooks.core/condplus-hook}}}
+  {clojure+.core/if+   clojure+.kondo-hooks/ifplus-hook
+   clojure+.core/when+ clojure+.kondo-hooks/whenplus-hook
+   clojure+.core/cond+ clojure+.kondo-hooks/condplus-hook}}}


### PR DESCRIPTION
clj-kondo might fail to lint properly if a different project also uses `hooks.core` as the namespace for the exported hooks. This was observed in a failed CI run. To make sure this was the issue, I asked on Clojurians and got confirmation from @borkdude [here](https://clojurians.slack.com/archives/CHY97NXE2/p1763470264085609). 

This PR renames the namespace to avoid clashes going forward.